### PR TITLE
Enable HT40 mode for 2.4 Ghz WiFi AP

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -238,6 +238,7 @@ gEnableLogp=1
 
 # Disable HT40
 gChannelBondingMode5GHz=1
+gChannelBondingMode24GHz=1
 
 # Enable Automatic Tx Power control
 gEnableAutomaticTxPowerControl=0


### PR DESCRIPTION
HT40 is disabled by default in Qualcomm WCNSS wlan driver source. Enabling this option will almost double the output (tested it myself, I got 40-50 Mbps on download and upload on 2 different WiFi networks)